### PR TITLE
isinf -> std::isinf in C++ code

### DIFF
--- a/src/ddm_fpt_lib.cpp
+++ b/src/ddm_fpt_lib.cpp
@@ -236,7 +236,7 @@ DMBase* DMBase::create(const ExtArray& drift, const ExtArray& sig2,
                        const ExtArray& b_lo_deriv, const ExtArray& b_up_deriv,
                        value_t dt, value_t invleak)
 {
-    const bool infinvleak = isinf(invleak);
+    const bool infinvleak = std::isinf(invleak);
     if (infinvleak) {
         const bool unit_sig2 = (sig2.isconst() && sig2[0] == 1.0);
         const bool constbounds = (b_lo.isconst() && b_up.isconst());


### PR DESCRIPTION
Running `python setup.py build` used to produce the following error on Ubuntu 17.04:

```
../src/ddm_fpt_lib.cpp:239:42: error: ‘isinf’ was not declared in this scope
     const bool infinvleak = isinf(invleak);
```

This change fixes it.