### PR TITLE
Fix bug with function call in matlab

### DIFF
--- a/matlab/README.md
+++ b/matlab/README.md
@@ -18,6 +18,7 @@ mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_fpt.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_fpt_full.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_sym.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_asym.cpp ../src/ddm_fpt_lib.cpp
+mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_full.cpp ../src/ddm_fpt_lib.cpp
 ```
 
 at the MATLAB prompt. Alternatively, the files can be compiled at the shell. Do do so, use
@@ -27,6 +28,7 @@ mex CXXFLAGS="$CXXFLAGS -std=c++11" ddm_fpt.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS="$CXXFLAGS -std=c++11" ddm_fpt_full.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS="$CXXFLAGS -std=c++11" ddm_rand_sym.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS="$CXXFLAGS -std=c++11" ddm_rand_asym.cpp ../src/ddm_fpt_lib.cpp
+mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_full.cpp ../src/ddm_fpt_lib.cpp
 ```
 
 at the Windows Command Prompt (using double quotes, (")), or
@@ -36,6 +38,7 @@ mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_fpt.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_fpt_full.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_sym.cpp ../src/ddm_fpt_lib.cpp
 mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_asym.cpp ../src/ddm_fpt_lib.cpp
+mex CXXFLAGS='$CXXFLAGS -std=c++11' ddm_rand_full.cpp ../src/ddm_fpt_lib.cpp
 ```
 
 at the Mac and Linux shell command line (using single quotes (')). Note that, for older versions of MATLAB, all occurences of `CXXFLAGS` might need to be replaced with `CFLAGS`.

--- a/matlab/ddm_fpt_full.m
+++ b/matlab/ddm_fpt_full.m
@@ -1,6 +1,6 @@
-[g1, g2] = ddm_fpt_full(mu, sig2, b_lo, b_up, b_lo_deriv, b_up_deriv, ...
+function [g1, g2] = ddm_fpt_full(mu, sig2, b_lo, b_up, b_lo_deriv, b_up_deriv, ...
                         delta_t, t_max, inv_leak)
-%% computes the diffusion model first-passage time distributions
+% computes the diffusion model first-passage time distributions
 %
 % The applied method is described in Smith (2000) "Stochastic Dynamic
 % Models of Response Time and Accuracy: A Foundational Primer" and other
@@ -46,4 +46,4 @@
 % All rights reserved.
 % See the file LICENSE for licensing information.
 
-error('Not implemented as M-file. Make sure that mex file is complied');
+error('Not implemented as M-file. Make sure that mex file is compiled');

--- a/matlab/ddm_rand_full.m
+++ b/matlab/ddm_rand_full.m
@@ -1,5 +1,5 @@
-[t, b] = ddm_rand_full(mu, sig2, b_lo, b_up, delta_t, n, inv_leak, seed)
-%% draw first-passage time samples and boundaries from a diffusion model.
+function [t, b] = ddm_rand_full(mu, sig2, b_lo, b_up, delta_t, n, inv_leak, seed)
+% draw first-passage time samples and boundaries from a diffusion model.
 %
 % Unless drift, variance and bounds are constant, the method uses the
 % Euler-Maruyama method to simulate the diffusion model.
@@ -29,4 +29,4 @@
 % All rights reserved.
 % See the file LICENSE for licensing information.
 
-error('Not implemented as M-file. Make sure that mex file is complied');
+error('Not implemented as M-file. Make sure that mex file is compiled');


### PR DESCRIPTION
ddm_rand_full.m (and others) are missing the function header. Therefore matlab is interpreting them as scripts, not functions.

Missing compilation line in matlab/README.rmd for ddm_rand_full.cpp